### PR TITLE
Support HTML image maps

### DIFF
--- a/helpers/parse.js
+++ b/helpers/parse.js
@@ -14,7 +14,9 @@ export const configuredXss = new xss.FilterXSS({
     kbd: ['id'],
     input: ['checked', 'disabled', 'type'],
     iframe: ['width', 'height', 'allowfullscreen', 'frameborder', 'start', 'end'],
-    img: [...xss.whiteList.img, 'style'],
+    img: [...xss.whiteList.img, 'style', 'usemap'],
+    map: ['name'],
+    area: [...xss.whiteList.a, 'coords']
     a: [...xss.whiteList.a, 'rel'],
   },
   css: {


### PR DESCRIPTION
I propose that project descriptions should be able to utilize HTML image maps. Because projects are already required to have adequate accessibility for screen readers, projects with images that currently have multiple images with multiple links can now streamline that process by having one image with an image map.

Pros
* Does not harm accessibility
* More flexible and engaging descriptions that utilize images
* Unique feature not supported by many other platforms

Cons
* Whitelisting new tags always increases the theoretical chance of XSS
    * I believe this to be minimal because this proposal extends the already-accepted `a` tags for `areas` and only adds additional declarative attributes with no new interpretable ones.