### PR TITLE
Prevent images from being treated as text in markdown

### DIFF
--- a/assets/styles/components.scss
+++ b/assets/styles/components.scss
@@ -616,6 +616,7 @@
   img {
     max-width: 100%;
     height: auto;
+    vertical-align: middle;
   }
 
   html:not(.dark-mode, .oled-mode) & img[src$='#gh-dark-mode-only'] {


### PR DESCRIPTION
Currently, images are treated as text in markdown, and text-related attributes are affecting layout (line height, etc.). This proposal fixes that issue by enforcing native image layout. This also prevents inline images without text between them from generating extra whitespace between them, allowing seamless images.

Before:
![image](https://user-images.githubusercontent.com/8730127/233854879-7ac6fc1d-dfc5-44a3-8ea4-3ac70e18bc87.png)

After:
![image](https://user-images.githubusercontent.com/8730127/233854884-ab8b1482-f331-40b0-bd5f-a61146a62e36.png)

